### PR TITLE
for v0.4.7-alpha26-cs1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+- build配下にリネーム漏れのフォルダが存在したのを修正
+
 ## v0.4.7-alpha26-cs1.0.0
 - Based on CasaOS-MessageBus v0.4.7-alpha26
 - Replaced module paths to use our own GitHub fork instead of the original IceWhaleTech repository  


### PR DESCRIPTION
- build配下にリネーム漏れのフォルダが存在したのを修正
